### PR TITLE
QueryBuilderDecorator improvements

### DIFF
--- a/src/Doctrine/QueryBuilderDecorator.php
+++ b/src/Doctrine/QueryBuilderDecorator.php
@@ -3,35 +3,106 @@
 namespace Digbang\Utils\Doctrine;
 
 use Digbang\Utils\Sorting;
+use Doctrine\ORM\Query\Expr;
+use Doctrine\ORM\Query\Expr\From;
+use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 
 class QueryBuilderDecorator extends QueryBuilder
 {
     public function __construct(QueryBuilder $queryBuilder)
     {
         parent::__construct($queryBuilder->getEntityManager());
+
+        $this->decorateDQLParts($queryBuilder->getDQLParts());
     }
 
     /**
-     * @return QueryBuilderDecorator
-     */
-    public function select($select = null)
-    {
-        /** @var static $queryBuilder */
-        $queryBuilder = parent::select($select);
-
-        return $queryBuilder;
-    }
-
-    /**
-     * @return QueryBuilderDecorator
+     * {@inheritDoc}
+     *
+     * @throws \InvalidArgumentException
      */
     public function from($from, $alias, $indexBy = null)
     {
-        /** @var static $queryBuilder */
-        $queryBuilder = parent::from($from, $alias, $indexBy);
+        $normalizedAlias = $this->normalizeAlias($alias);
+        $this->assertHasOneAlias($normalizedAlias);
+        $firstAlias = $normalizedAlias->first();
 
-        return $queryBuilder;
+        /** @var From $_from */
+        foreach ($this->getDQLPart('from') as $_from) {
+            if (($_from->getAlias() === $firstAlias) && ($_from->getFrom() !== $from)) {
+                throw new \InvalidArgumentException("Duplicated FROM alias: $firstAlias.");
+            }
+        }
+
+        return parent::from($from, $firstAlias, $indexBy);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function select($select = null)
+    {
+        $selects = is_array($select) ? $select : func_get_args();
+        $normalizedSelects = $this->normalizeAlias($selects);
+
+        return parent::select($normalizedSelects->toArray());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function addSelect($select = null)
+    {
+        $selects = is_array($select) ? $select : func_get_args();
+        $normalizedSelects = $this->normalizeAlias($selects);
+
+        /** @var Collection $dqlSelectParts */
+        $dqlSelectParts = collect($this->getDQLPart('select'))
+            ->flatMap
+            ->getParts();
+
+        $newSelects = $normalizedSelects->diff($dqlSelectParts);
+
+        return parent::addSelect($newSelects->toArray());
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function innerJoin($join, $alias, $conditionType = null, $condition = null, $indexBy = null)
+    {
+        $normalizedAlias = $this->normalizeAlias($alias);
+        $this->assertHasOneAlias($normalizedAlias);
+        $firstAlias = $normalizedAlias->first();
+
+        if ($this->isJoined($alias, Join::INNER_JOIN)) {
+            return $this->mergeJoinConditions($alias, $conditionType, $condition);
+        }
+
+        return parent::innerJoin($join, $firstAlias, $conditionType, $condition, $indexBy);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function leftJoin($join, $alias, $conditionType = null, $condition = null, $indexBy = null)
+    {
+        $normalizedAlias = $this->normalizeAlias($alias);
+        $this->assertHasOneAlias($normalizedAlias);
+        $firstAlias = $normalizedAlias->first();
+
+        if ($this->isJoined($alias, Join::LEFT_JOIN)) {
+            return $this->mergeJoinConditions($alias, $conditionType, $condition);
+        }
+
+        return parent::leftJoin($join, $firstAlias, $conditionType, $condition, $indexBy);
     }
 
     /**
@@ -119,6 +190,141 @@ class QueryBuilderDecorator extends QueryBuilder
         $expr = $this->expr();
         if (! empty($filters)) {
             $this->where($expr->andX(...$filters));
+        }
+
+        return $this;
+    }
+
+    /**
+     * Pre: Receive a DQLParts array.
+     *
+     * Post: Fill the current instance DQLParts with the given ones.
+     *
+     * @param array $dqlParts
+     *
+     * @return void
+     */
+    private function decorateDQLParts(array $dqlParts): void
+    {
+        $filledDQLParts = array_filter($dqlParts);
+
+        foreach ($filledDQLParts as $key => $value) {
+            $this->add($key, $value, false);
+        }
+    }
+
+    /**
+     * Pre: Receive an array or string like one of the following (with all it's variants):
+     * a) 'a, b, c'
+     * b) ['a as foo, b, c']
+     * c) ['a as foo', 'b', 'c']
+     *
+     * Post: Return a normalized array like the following: ['a', 'b', 'c']
+     *
+     * Normalized array means no NULL, empty strings, duplicates or ' ' like should be inside of it.
+     *
+     * @param string|array $alias
+     *
+     * @return Collection
+     */
+    private function normalizeAlias($alias): Collection
+    {
+        return Str::of(collect($alias)->join(','))
+            ->explode(',')
+            ->map(function (string $value) {
+                return trim($value);
+            })
+            ->filter()
+            ->unique()
+            ->values();
+    }
+
+    /**
+     * Pre: Receive an alias collection
+     *
+     * Post: Throw an \InvalidArgumentException if the alias is empty or has more than one alias
+     *
+     * @param Collection $alias
+     *
+     * @throws \InvalidArgumentException
+     */
+    private function assertHasOneAlias(Collection $alias): void
+    {
+        if ($alias->count() != 1) {
+            throw new \InvalidArgumentException("There should be one alias on the current context.");
+        }
+    }
+
+    /**
+     * Pre: Receive two strings: join alias and type.
+     *
+     * Post: Return a true if the join was defined before, otherwhise return false. \InvalidArgumentException may be
+     * thrown if the alias was defined for a different join type.
+     *
+     * @param string $alias
+     * @param string $joinType
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return bool
+     */
+    protected function isJoined(string $alias, string $joinType): bool
+    {
+        /** @var Join[] $joins */
+        $joins = collect($this->getDQLPart('join'))->flatten();
+
+        foreach ($joins as $join) {
+            if ($join->getAlias() !== $alias) {
+                continue;
+            }
+
+            if ($join->getJoinType() === $joinType) {
+                return true;
+            }
+
+            throw new \InvalidArgumentException("Alias '$alias' is defined for a different join type: {$join->getJoinType()}.");
+        }
+
+        return false;
+    }
+
+    /**
+     * Pre: Receive the alias, condition type and the join condition as strings.
+     *
+     * Post: Merge the given condition with the desired join.
+     *
+     * @param string $alias
+     * @param null|string $conditionType
+     * @param null|string|Expr\Comparison|Expr\Func|Expr\Orx $condition
+     *
+     * @return QueryBuilderDecorator
+     */
+    protected function mergeJoinConditions(string $alias, ?string $conditionType = Join::WITH, $condition = null): self
+    {
+        if (is_null($condition)) {
+            return $this;
+        }
+
+        /** @var Join[] $joins */
+        foreach ($this->getDQLPart('join') as $key => $joins) {
+            foreach ($joins as $index => $join) {
+                if ($join->getAlias() !== $alias) {
+                    continue;
+                }
+
+                if (is_null($join->getConditionType()) || $join->getConditionType() === $conditionType) {
+                    $joins[$index] = new Join(
+                        $join->getJoinType(),
+                        $join->getJoin(),
+                        $join->getAlias(),
+                        $conditionType,
+                        (string)$this->expr()->andX($join->getCondition(), $condition),
+                        $join->getIndexBy()
+                    );
+
+                    return $this->add('join', [$key => $joins], false);
+                }
+            }
         }
 
         return $this;

--- a/src/Doctrine/QueryBuilderDecorator.php
+++ b/src/Doctrine/QueryBuilderDecorator.php
@@ -45,9 +45,11 @@ class QueryBuilderDecorator extends QueryBuilder
     public function select($select = null)
     {
         $selects = is_array($select) ? $select : func_get_args();
-        $normalizedSelects = $this->normalizeAlias($selects);
 
-        return parent::select($normalizedSelects->toArray());
+        return parent::select(collect($selects)
+            ->unique()
+            ->toArray()
+        );
     }
 
     /**
@@ -56,15 +58,17 @@ class QueryBuilderDecorator extends QueryBuilder
     public function addSelect($select = null)
     {
         $selects = is_array($select) ? $select : func_get_args();
-        $normalizedSelects = $this->normalizeAlias($selects);
         $dqlSelectParts = collect();
 
         /** @var Select $part */
         foreach ($this->getDQLPart('select') as $part) {
-            $dqlSelectParts = $dqlSelectParts->merge($this->normalizeAlias($part->getParts()));
+            foreach ($part->getParts() as $element) {
+                $dqlSelectParts->add($element);
+            }
         }
 
-        return parent::addSelect($normalizedSelects
+        return parent::addSelect(collect($selects)
+            ->unique()
             ->diff($dqlSelectParts)
             ->toArray()
         );

--- a/src/Doctrine/QueryBuilderDecorator.php
+++ b/src/Doctrine/QueryBuilderDecorator.php
@@ -6,6 +6,7 @@ use Digbang\Utils\Sorting;
 use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\Query\Expr\From;
 use Doctrine\ORM\Query\Expr\Join;
+use Doctrine\ORM\Query\Expr\Select;
 use Doctrine\ORM\QueryBuilder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
@@ -58,11 +59,12 @@ class QueryBuilderDecorator extends QueryBuilder
     {
         $selects = is_array($select) ? $select : func_get_args();
         $normalizedSelects = $this->normalizeAlias($selects);
+        $dqlSelectParts = collect();
 
-        /** @var Collection $dqlSelectParts */
-        $dqlSelectParts = collect($this->getDQLPart('select'))
-            ->flatMap
-            ->getParts();
+        /** @var Select $_select */
+        foreach ($this->getDQLPart('select') as $_select) {
+            $dqlSelectParts = $dqlSelectParts->merge($this->normalizeAlias($_select->getParts()));
+        }
 
         $newSelects = $normalizedSelects->diff($dqlSelectParts);
 

--- a/src/Doctrine/QueryBuilderDecorator.php
+++ b/src/Doctrine/QueryBuilderDecorator.php
@@ -114,14 +114,18 @@ class QueryBuilderDecorator extends QueryBuilder
      *
      * @param mixed $value
      * @param \Closure $callback
+     *
+     * @return QueryBuilderDecorator
      */
-    public function when($value, \Closure $callback): void
+    public function when($value, \Closure $callback): self
     {
         if (is_null($value)) {
-            return;
+            return $this;
         }
 
         $callback->__invoke($this, $value);
+
+        return $this;
     }
 
     /**

--- a/src/Doctrine/QueryBuilderDecorator.php
+++ b/src/Doctrine/QueryBuilderDecorator.php
@@ -108,6 +108,23 @@ class QueryBuilderDecorator extends QueryBuilder
     }
 
     /**
+     * Pre: Receive a value and a callback.
+     *
+     * Post: Execute the callback if the given value is not null.
+     *
+     * @param mixed $value
+     * @param \Closure $callback
+     */
+    public function when($value, \Closure $callback): void
+    {
+        if (is_null($value)) {
+            return;
+        }
+
+        $callback->__invoke($this, $value);
+    }
+
+    /**
      * Adds "order by" statement if sort is found in sortOptions.
      * Returns true if order by was added.
      * sortOptions example:

--- a/src/Doctrine/QueryBuilderDecorator.php
+++ b/src/Doctrine/QueryBuilderDecorator.php
@@ -291,7 +291,7 @@ class QueryBuilderDecorator extends QueryBuilder
      *
      * @return bool
      */
-    protected function isJoined(string $alias, string $joinType): bool
+    private function isJoined(string $alias, string $joinType): bool
     {
         /** @var Join[] $joins */
         $joins = collect($this->getDQLPart('join'))->flatten();
@@ -322,7 +322,7 @@ class QueryBuilderDecorator extends QueryBuilder
      *
      * @return QueryBuilderDecorator
      */
-    protected function mergeJoinConditions(string $alias, ?string $conditionType = Join::WITH, $condition = null): self
+    private function mergeJoinConditions(string $alias, ?string $conditionType = Join::WITH, $condition = null): self
     {
         if (is_null($condition)) {
             return $this;
@@ -335,18 +335,19 @@ class QueryBuilderDecorator extends QueryBuilder
                     continue;
                 }
 
-                if (is_null($join->getConditionType()) || $join->getConditionType() === $conditionType) {
-                    $joins[$index] = new Join(
-                        $join->getJoinType(),
-                        $join->getJoin(),
-                        $join->getAlias(),
-                        $conditionType,
-                        (string)$this->expr()->andX($join->getCondition(), $condition),
-                        $join->getIndexBy()
-                    );
+                $newConditionType = in_array(Join::ON, [$join->getConditionType(), $conditionType]) ? Join::ON : Join::WITH;
+                $newCondition = $this->expr()->andX($join->getCondition(), $condition);
 
-                    return $this->add('join', [$key => $joins], false);
-                }
+                $joins[$index] = new Join(
+                    $join->getJoinType(),
+                    $join->getJoin(),
+                    $join->getAlias(),
+                    $newConditionType,
+                    $newCondition,
+                    $join->getIndexBy()
+                );
+
+                return $this->add('join', [$key => $joins], false);
             }
         }
 

--- a/src/Doctrine/QueryBuilderDecorator.php
+++ b/src/Doctrine/QueryBuilderDecorator.php
@@ -31,7 +31,7 @@ class QueryBuilderDecorator extends QueryBuilder
 
         /** @var From $part */
         foreach ($this->getDQLPart('from') as $part) {
-            if (($part->getAlias() === $singleAlias) && ($part->getFrom() !== $from)) {
+            if ($part->getAlias() === $singleAlias && $part->getFrom() !== $from) {
                 throw new \InvalidArgumentException("Duplicated FROM alias: $singleAlias.");
             }
         }
@@ -115,8 +115,6 @@ class QueryBuilderDecorator extends QueryBuilder
      *    ]
      * ].
      *
-     * @deprecated
-     *
      * @param Sorting $sorting
      * @param array $sortOptions
      *
@@ -134,8 +132,6 @@ class QueryBuilderDecorator extends QueryBuilder
     /**
      * Adds "order by" statement with raw PaginationData sorting values
      * Returns true if order by was added.
-     *
-     * @deprecated
      *
      * @param Sorting $sorting
      *
@@ -183,8 +179,6 @@ class QueryBuilderDecorator extends QueryBuilder
 
     /**
      * Adds "andWhere's" statements for each filter.
-     *
-     * @deprecated
      *
      * @param array $filters
      *
@@ -259,7 +253,7 @@ class QueryBuilderDecorator extends QueryBuilder
     {
         $normalizedAlias = $this->normalizeAlias($alias);
 
-        if ($normalizedAlias->count() != 1) {
+        if ($normalizedAlias->count() !== 1) {
             throw new \InvalidArgumentException('There should be one alias on the current context.');
         }
 


### PR DESCRIPTION
$oqb = $em->createQueryBuilder(); // Original QueryBuilder
$oqb->from(Person::class, 'p');
$oqb->select('p');

Ahora la instancia decorada tiene los mismos dqlParts que $oqb
$dqb = new QueryBuilderDecorator($oqb); // DecoratedQueryBuilder

Ahora se pueden combinar **from**
$dqb->from(Person::class, 'p');
$dqb->from(Person::class, 'p');
$dqb->from(User::class, 'p'); // Esto tira una excepción
$dqb->from(Person::class, 'c'); // Esto NO tira una excepción

Ahora se pueden combinar **select**
$dqb->addSelect('p, u');
$dqb->addSelect('c');

Ahora se pueden combinar **conditions** en los joins (toma precedencia el ON, de existir)
$dqb->join('p.user', 'u');
$dqb->join('p.user', 'u', Join::WITH, 'u.activationDate IS NOT NULL');
$dqb->leftJoin('p.user', 'u'); // Esto tira una excepción, ya que el alias está en uso para otro tipo de JOIN