### PR TITLE
PCT-11261 | Add Laravel 11 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,10 @@
     ],
     "require": {
         "php": "^8.0.2",
-        "illuminate/support": "^8.0 || ^9.0 || ^10.0",
-        "illuminate/contracts": "^8.0 || ^9.0 || ^10.0",
-        "illuminate/http": "^8.0 || ^9.0 || ^10.0",
-        "illuminate/pagination": "^8.0 || ^9.0 || ^10.0",
+        "illuminate/support": "^8.0 || ^9.0 || ^10.0 || ^11.0",
+        "illuminate/contracts": "^8.0 || ^9.0 || ^10.0 || ^11.0",
+        "illuminate/http": "^8.0 || ^9.0 || ^10.0 || ^11.0",
+        "illuminate/pagination": "^8.0 || ^9.0 || ^10.0 || ^11.0",
         "laravel-doctrine/fluent": "^1.2 || ^3.0",
         "laravel-doctrine/orm": "^1.7 || ^3.2"
     },


### PR DESCRIPTION
Widens illuminate/* constraints to include ^11.0 for the L10 → L13 upgrade project. No code changes.